### PR TITLE
Fix that the mirror site returns an incorrect status code for non-existent files.

### DIFF
--- a/1_其一,setupDecomp,请先运行此脚本,再打开IDE.bat
+++ b/1_其一,setupDecomp,请先运行此脚本,再打开IDE.bat
@@ -5,5 +5,5 @@ if errorlevel 1 (
     set "JAVA_TOOL_OPTIONS=%JAVA_TOOL_OPTIONS% -Dfile.encoding=UTF-8"
 )
 chcp 65001
-call gradlew.bat setupDecompWorkspace
+call gradlew.bat setupDecompWorkspace idea genIntellijRuns
 pause

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ repositories {
         }
         // add mirror repositories
         maven { url "https://maven.aliyun.com/nexus/content/groups/public" }
+        maven { url "file://${projectDir}/.gradle/local-repo" }
         maven { url "https://${mirror_maven_url}" }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,9 @@ use_mirror_url=true
 #mirror_maven_url=crystal.app.lss233.com/repositories/minecraft
 mirror_maven_url=download.mcbbs.net/maven
 
+#mirror_assets_url=bmclapi2.bangbang93.com
+mirror_assets_url=download.mcbbs.net
+
 # Increase timeout for HTTP timeouts, see https://github.com/gradle/gradle/pull/3371
 systemProp.http.connectionTimeout=60000
 systemProp.http.socketTimeout=6000

--- a/mirror.gradle
+++ b/mirror.gradle
@@ -17,6 +17,9 @@ import net.minecraftforge.gradle.util.json.version.Library
 import sun.misc.SharedSecrets
 import sun.misc.Unsafe
 
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
 // initialize the constant pool and force to load strings so that strings can be replaced
 void initConstantPool(Class<?> clazz) {
     if (clazz != null && !clazz.interface) {
@@ -62,7 +65,7 @@ for (clazz in classToInit) {
     initConstantPool Unsafe.theUnsafe.allocateInstance(clazz).class
 }
 
-replaceString "https://launchermeta.mojang.com/mc/game/version_manifest.json", redirectUrl("https://bmclapi2.bangbang93.com/mc/game/version_manifest.json")
+replaceString "https://launchermeta.mojang.com/mc/game/version_manifest.json", redirectUrl("https://${mirror_assets_url}/mc/game/version_manifest.json")
 replaceString "http://resources.download.minecraft.net/", "https://download.mcbbs.net/assets/" // use MCBBS mirror due to there"s no way to hook http 302 response when downloading assets
 replaceString "https://libraries.minecraft.net/", "https://${mirror_maven_url}"
 replaceString "https://maven.minecraftforge.net", "https://${mirror_maven_url}"
@@ -81,7 +84,7 @@ task mirrorManifest {
             it.setAccessible true
             it
         } get forge get forge.extension.version with {
-            if (it.url != null) it.url = redirectUrl it.url.replace("launchermeta.mojang.com", "bmclapi2.bangbang93.com")
+            if (it.url != null) it.url = redirectUrl it.url.replace("launchermeta.mojang.com", mirror_assets_url)
         }
     }
 }
@@ -94,10 +97,58 @@ task mirrorVersionJson {
             it.setAccessible true
             it
         } get forge with {
-            it.assetIndex.url = redirectUrl it.assetIndex.url.replace("launchermeta.mojang.com", "bmclapi2.bangbang93.com")
+            it.assetIndex.url = redirectUrl it.assetIndex.url.replace("launchermeta.mojang.com", mirror_assets_url)
             it.downloads.values().each {
-                if (it.url != null) it.url = redirectUrl it.url.replace("launcher.mojang.com", "bmclapi2.bangbang93.com")
+                if (it.url != null) it.url = redirectUrl it.url.replace("launcher.mojang.com", mirror_assets_url)
             }
         }
+    }
+}
+
+afterEvaluate {
+    ForgePlugin forge = project.plugins.findPlugin ForgePlugin.class
+
+    def mcpName = forge.delayedString("mcp_${Constants.REPLACE_MCP_CHANNEL}").call()
+    def mcpVersion = forge.delayedString("${Constants.REPLACE_MCP_VERSION}-${Constants.REPLACE_MCP_MCVERSION}").call()
+    def mcpBasePath = "/de/oceanlabs/mcp/${mcpName}/${mcpVersion}/${mcpName}-${mcpVersion}."
+    def mcpBaseUrl = "https://${mirror_maven_url}${mcpBasePath}"
+    new URL("${mcpBaseUrl}zip").withInputStream { is ->
+        Files.copy(is, file("${projectDir}/.gradle/local-repo${mcpBasePath}zip").toPath().with { path ->
+            Files.createDirectories(path.parent)
+            path
+        }, StandardCopyOption.REPLACE_EXISTING)
+    }
+    file("${projectDir}/.gradle/local-repo${mcpBasePath}pom").withWriter { writer ->
+        writer.write("""\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>de.oceanlabs.mcp</groupId>
+                <artifactId>${mcpName}</artifactId>
+                <version>${mcpVersion}</version>
+                <packaging>zip</packaging>
+            </project>
+            """.stripIndent())
+    }
+
+    def mcVersion = forge.delayedString("${Constants.REPLACE_MC_VERSION}").call()
+    def mcBasePath = "/de/oceanlabs/mcp/mcp/${mcVersion}/mcp-${mcVersion}"
+    def mcBaseUrl = "https://${mirror_maven_url}${mcBasePath}"
+    new URL("${mcBaseUrl}-srg.zip").withInputStream { is ->
+        Files.copy(is, file("${projectDir}/.gradle/local-repo${mcBasePath}-srg.zip").toPath().with { path ->
+            Files.createDirectories(path.parent)
+            path
+        }, StandardCopyOption.REPLACE_EXISTING)
+    }
+    file("${projectDir}/.gradle/local-repo${mcBasePath}.pom").withWriter { writer ->
+        writer.write("""\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>de.oceanlabs.mcp</groupId>
+                <artifactId>mcp</artifactId>
+                <version>${mcVersion}</version>
+            </project>
+            """.stripIndent())
     }
 }


### PR DESCRIPTION
部分 pom 文件上游源站不存在，不论是 MCBBS 镜像还是 Lss233 镜像都没有办法在一定时间内正确返回 404 导致相当一部分人构建失败，因此这个 PR 将提前下载这些 pom 对应的 zip/jar 文件，并且生成一个 pom 以供正确读取